### PR TITLE
Replace platform detection macros with simple `final val` definitions…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,6 @@ lazy val platform = crossProject.crossType(CrossType.Dummy)
   .dependsOn(macros)
   .settings(moduleName := "catalysts-platform")
   .settings(catalystsSettings:_*)
-  .settings(scalaMacroDependencies(paradiseVersion):_*)
   .jsSettings(commonJsSettings:_*)
   .jvmSettings(commonJvmSettings:_*)
 

--- a/platform/js/src/main/scala/catalysts/Platform_js.scala
+++ b/platform/js/src/main/scala/catalysts/Platform_js.scala
@@ -1,18 +1,9 @@
 package catalysts
 
-import scala.reflect.macros.whitebox
-import macrocompat.bundle
-
 object Platform {
-  def isJvm: Boolean = macro PlatformMacros.isJvmImpl
-  def isJs: Boolean = macro PlatformMacros.isJsImpl
-}
-
-@bundle
-class PlatformMacros(val c: whitebox.Context) {
-  import c.universe._
-
-  def isJvmImpl: c.Expr[Boolean] = c.Expr(Literal(Constant(false)))
-
-  def isJsImpl: c.Expr[Boolean] = c.Expr(Literal(Constant(true)))
+  // using `final val` makes compiler constant-fold any use of these values, dropping dead code automatically
+  // $COVERAGE-OFF$
+  final val isJvm = false
+  final val isJs = true
+  // $COVERAGE-ON$
 }

--- a/platform/jvm/src/main/scala/catalysts/Platform_jvm.scala
+++ b/platform/jvm/src/main/scala/catalysts/Platform_jvm.scala
@@ -1,18 +1,9 @@
 package catalysts
 
-import scala.reflect.macros.whitebox
-import macrocompat.bundle
-
 object Platform {
-  def isJvm: Boolean = macro PlatformMacros.isJvmImpl
-  def isJs: Boolean = macro  PlatformMacros.isJsImpl
-}
-
-@bundle
-class PlatformMacros(val c: whitebox.Context) {
-  import c.universe._
-
-  def isJvmImpl: c.Expr[Boolean] = c.Expr(Literal(Constant(true)))
-
-  def isJsImpl: c.Expr[Boolean] = c.Expr(Literal(Constant(false)))
+  // using `final val` makes compiler constant-fold any use of these values, dropping dead code automatically
+  // $COVERAGE-OFF$
+  final val isJvm = true
+  final val isJs = false
+  // $COVERAGE-ON$
 }

--- a/tests/src/test/scala/catalysts/tests/PlatformTests.scala
+++ b/tests/src/test/scala/catalysts/tests/PlatformTests.scala
@@ -21,5 +21,14 @@ class PlatformTests extends TestSuite {
     assert(Platform.isJs != Platform.isJvm)
     assert(hackyIsJS != hackyIsJVM)
   }
-}
 
+  test("dead code elimination") {
+    // look at disassembled class files to verify this reduces to a `bipush 42` or `bipush 43`
+    val x = if( Platform.isJvm ) {
+      42
+    } else {
+      43
+    }
+    assert(Platform.isJvm || x == 43)
+  }
+}

--- a/tests/src/test/scala/catalysts/tests/PlatformTests.scala
+++ b/tests/src/test/scala/catalysts/tests/PlatformTests.scala
@@ -24,11 +24,7 @@ class PlatformTests extends TestSuite {
 
   test("dead code elimination") {
     // look at disassembled class files to verify this reduces to a `bipush 42` or `bipush 43`
-    val x = if( Platform.isJvm ) {
-      42
-    } else {
-      43
-    }
+    val x = if( Platform.isJvm ) 42 else 43
     assert(Platform.isJvm || x == 43)
   }
 }


### PR DESCRIPTION
… that the compiler can constant-fold at call site. Fixes #22.