### PR TITLE
Wip/new plugin

### DIFF
--- a/base.sbt
+++ b/base.sbt
@@ -1,2 +1,1 @@
 addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\"")
-enablePlugins(GitBranchPrompt)

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val docs = project.configure(mkDocConfig(gh, rootSettings, commonJvmSetting
 lazy val buildSettings = sharedBuildSettings(gh, vers)
 
 lazy val commonSettings = sharedCommonSettings ++ Seq(
-  scalacOptions ++= commonScalacOptions,
+  scalacOptions ++= scalacAllOptions,
   parallelExecution in Test := false
 ) ++ warnUnusedImport ++ unidocCommonSettings
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -1,3 +1,5 @@
+package sbtcatalysts
+
 import sbt._
 import sbt.Keys._
 
@@ -19,35 +21,62 @@ import ReleaseTransformations._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import ScalaJSPlugin.autoImport._
 import scoverage.ScoverageSbtPlugin._
-import org.scalajs.sbtplugin.cross.CrossProject
+import org.scalajs.sbtplugin.cross.{CrossProject, CrossType}
 
 object Base {
 
-  implicit class VersionsOps(v: Map[String, String]) {
-    def ->(s: String) = v.get(s).get
+  type VersionsType = Map[String, String]
+  type LibrariesType = Map[String, (String, String, String)]
+
+  // Licences
+  val apache = ("Apache License", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+  val mit = ("MIT", url("http://opensource.org/licenses/MIT"))
+
+  // Github settings and devs
+  case class GitHubSettings(org: String, proj: String, publishOrg: String, license: (String, URL)) {
+
+    def home = s"https://github.com/$org/$proj"
+    def repo = s"git@github.com:$org/$proj.git"
+    def api  = s"https://$org.github.io/$proj/api/"
+    def organisation  = s"com.github.$org"
+    override def toString = s"GitHubSettings:home = $home\nGitHubSettings:repo = $repo\nGitHubSettings:api = $api\nGitHubSettings:organisation = $organisation"
   }
 
-  val versions = Map[String, String](
-    "discipline" -> "0.4",
-    "macro-compat" -> "1.0.0",
-    "paradise" -> "2.1.0-M5",
-    "scalacheck" -> "1.12.4",
-    "scalatest" -> "3.0.0-M7",
-    "scalac" -> "2.11.7",
-    "specs2" -> "3.6.4"
-  )
+  // From https://github.com/typelevel/sbt-typelevel/blob/master/src/main/scala/Developer.scala
+  case class Dev(name: String, id: String) {
+    def pomExtra: xml.NodeSeq = (
+      <developer>
+        <id>{ id }</id>
+        <name>{ name }</name>
+        <url>http://github.com/{ id }</url>
+          </developer>
+    )
+  }
 
+  // These three addLib methods need DRYing
+  def addLibs(vl: (VersionsType, LibrariesType), s: String*) = {
+    s.map(s => Seq(libraryDependencies += vl._2(s)._2 %%% vl._2(s)._3  % vl._1(vl._2(s)._1) )).flatten
+  }
 
+  def addCompileLibs(vl: (VersionsType, LibrariesType), s: String*) = {
+    s.map(s => Seq(libraryDependencies += vl._2(s)._2 %%% vl._2(s)._3  % vl._1(vl._2(s)._1)  % "compile")).flatten
+  }
+
+  def addTestLibs(vl: (VersionsType, LibrariesType), s: String*) = {
+    s.map(s => Seq(libraryDependencies += vl._2(s)._2 %%% vl._2(s)._3  % vl._1(vl._2(s)._1)  % "test")).flatten
+  }
+
+  // Common and shared setting 
   lazy val noPublishSettings = Seq(
     publish := (),
     publishLocal := (),
     publishArtifact := false
   )
-  
+
   lazy val rootSettings = noPublishSettings ++ Seq(
     moduleName := "root"
   )
-  
+
   lazy val crossVersionSharedSources: Seq[Setting[_]] =
     Seq(Compile, Test).map { sc =>
       (unmanagedSourceDirectories in sc) ++= {
@@ -74,7 +103,7 @@ object Base {
             compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full),
                 "org.scalamacros" %% "quasiquotes" % version cross CrossVersion.binary
           )
-      } 
+      }
     }
   )
 
@@ -101,11 +130,17 @@ object Base {
     updateOptions := updateOptions.value.withCachedResolution(true)
   )
 
-  def sharedPublishSettings(home: String, repo: String, api: String, license: (String, URL), devs: Seq[Dev]): Seq[Setting[_]] = Seq(
-    homepage := Some(url(home)),
-    licenses += license,
-    scmInfo :=  Some(ScmInfo(url(home), "scm:git:" + repo)),
-    apiURL := Some(url(api)),
+  def sharedBuildSettings(gh: GitHubSettings, vers: VersionsType) = Seq(
+    organization := gh.publishOrg,
+    scalaVersion := vers("scalac"),
+    crossScalaVersions := Seq(vers("scalac_2.10"), scalaVersion.value)
+  )
+
+  def sharedPublishSettings(gh: GitHubSettings, devs: Seq[Dev]): Seq[Setting[_]] = Seq(
+    homepage := Some(url(gh.home)),
+    licenses += gh.license,
+    scmInfo :=  Some(ScmInfo(url(gh.home), "scm:git:" + gh.repo)),
+    apiURL := Some(url(gh.api)),
     releaseCrossBuild := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     publishMavenStyle := true,
@@ -142,7 +177,7 @@ object Base {
     ScoverageKeys.coverageMinimum := min,
     ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := scalaBinaryVersion.value != "2.10"
-      // ScoverageKeys.coverageExcludedPackages := "catalysts\\.bench\\..*"
+    // ScoverageKeys.coverageExcludedPackages := "catalysts\\.bench\\..*"
   )
 
   lazy val unidocCommonSettings = Seq(
@@ -170,47 +205,103 @@ object Base {
     } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
   )
 
-  // From https://github.com/typelevel/sbt-typelevel/blob/master/src/main/scala/Developer.scala
-  case class Dev(name: String, id: String) {
-    def pomExtra: xml.NodeSeq = (
-      <developer>
-        <id>{ id }</id>
-        <name>{ name }</name>
-        <url>http://github.com/{ id }</url>
-          </developer>
-    )
+  // Builder methods
+
+  /**
+   * Creates a module definition based on a Scala.js CrossProject
+   * 
+   * The standard Scala.js CrossProject contains the real JVM and JS project
+   * and can be used as a dependcy of another CrossProject. But it not an 
+   * sbt Project, and cannot be used as one.
+   * 
+   * So we introduce the concept of a Module, that is essentialy a CrossProject
+   * with the difference that the variable name is the directory name with the 
+   * suffix "M". This allows us to create a real project based on the dirctory name
+   * that is an aggregate project for the underlying JS and JVM projects.
+   * 
+   * Usage;
+   * 
+   * In build.sbt, create two helper methods:
+   * 
+   *   lazy val module = mkModuleFactory(gh.proj, mkConfig(rootSettings, commonJvmSettings, commonJsSettings))
+   *   lazy val prj = mkPrjFactory(rootSettings)
+   * 
+   * For each sub-project (here core is used as an example)
+   * 
+   *   lazy val core    = prj(coreM)
+   *   lazy val coreJVM = coreM.jvm
+   *   lazy val coreJS  = scalatestM.js
+   *   lazy val coreM   = module("core",CrossType.Pure)
+   *     .dependsOn(testkitM)
+   *     .settings(addTestLibs(vlibs, "scalatest"):_*)
+   */
+  def mkModule(proj: String, projConfig: CrossProject ⇒ CrossProject, id: String,
+      crossType: CrossType = CrossType.Pure ): CrossProject = {
+    
+    val cpId = id.stripSuffix("M")
+
+    CrossProject(cpId, new File(cpId), crossType)
+     .settings(moduleName := s"$proj-$id")
+    .configure(projConfig)
   }
 
+  /**
+   * Helper method for mkModule so that the main project name anf configuration need not ne repeated for each module
+   */
+  def mkModuleFactory(proj: String, projConfig: CrossProject ⇒ CrossProject) =
+    (id: String, crossType: CrossType) => mkModule(proj, projConfig, id, crossType)
+
+  /**
+   * Makes a modules aggregate project
+   */
+  def mkPrj(projSettings: Seq[sbt.Setting[_]], c: CrossProject): Project = {
+      val name = c.jvm.id.stripSuffix("JVM")
+      val pr: Seq[ProjectReference] = Seq(c.jvm.project,  c.js.project)
+
+      Project(id = name, base = new File(s"${name}/.prj"))
+        .settings(noPublishSettings:_*)
+        .settings(projSettings)
+        .dependsOn(c.jvm, c.js)
+        .aggregate(c.jvm, c.js)
+   }
+
+  /**
+   * Helper method for mkPrj so that the main project settings need not ne repeated for each module
+   */
+  def mkPrjFactory(projSettings: Seq[sbt.Setting[_]]) = (c: CrossProject) => mkPrj(projSettings, c)
+
+  // Config builders
   def mkConfig(projSettings: Seq[sbt.Setting[_]], jvmSettings: Seq[sbt.Setting[_]],
-    jsSettings: Seq[sbt.Setting[_]] ): CrossProject ⇒ CrossProject =
+      jsSettings: Seq[sbt.Setting[_]] ): CrossProject ⇒ CrossProject =
     _.settings(projSettings:_*)
-      .jsSettings(jsSettings:_*)
-      .jvmSettings(jvmSettings:_*)
+    .jsSettings(jsSettings:_*)
+    .jvmSettings(jvmSettings:_*)
 
   def mkRootConfig(projSettings: Seq[sbt.Setting[_]] , projJVM:Project): Project ⇒ Project =
     _.in(file("."))
-      .settings(rootSettings)
-      .settings(projSettings)
-      .settings(console <<= console in (projJVM, Compile))
+    .settings(rootSettings)
+    .settings(projSettings)
+    .settings(console <<= console in (projJVM, Compile))
 
-  def mkRootJvmConfig(s: String, projSettings: Seq[sbt.Setting[_]] , jvmSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+  def mkRootJvmConfig(s: String, projSettings: Seq[sbt.Setting[_]],
+      jvmSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
     _.settings(moduleName := s)
-      .settings(projSettings)
-      .settings(jvmSettings)
-      .in(file("." + s + "JVM"))
+    .settings(projSettings)
+    .settings(jvmSettings)
+    .in(file("." + s + "JVM"))
 
-  def mkRootJsConfig(s: String, projSettings: Seq[sbt.Setting[_]] , jsSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+  def mkRootJsConfig(s: String, projSettings: Seq[sbt.Setting[_]],
+      jsSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
     _.settings(moduleName := s)
-      .settings(projSettings)
-      .settings(jsSettings)
-      .in(file("." + s + "JS"))
-      .enablePlugins(ScalaJSPlugin)
+    .settings(projSettings)
+    .settings(jsSettings)
+    .in(file("." + s + "JS"))
+    .enablePlugins(ScalaJSPlugin)
 
-  def mkDocConfig(proj: String, repo: String, org:String,  projSettings: Seq[sbt.Setting[_]] , jvmSettings: Seq[sbt.Setting[_]],
+  def mkDocConfig(gh: GitHubSettings, projSettings: Seq[sbt.Setting[_]], jvmSettings: Seq[sbt.Setting[_]],
       deps: Project*): Project ⇒ Project =
-
     _.settings(projSettings)
-    .settings(moduleName := proj + "-docs")
+    .settings(moduleName := gh.proj + "-docs")
     .settings(noPublishSettings)
     .settings(unidocSettings)
     .settings(site.settings)
@@ -219,19 +310,19 @@ object Base {
     .settings(jvmSettings)
     .dependsOn(deps.map( ClasspathDependency(_, Some("compile;test->test")))  :_*) //platformJVM, macrosJVM, scalatestJVM, specs2, testkitJVM)
     .settings(
-       organization  := org,
+       organization  := gh.organisation,
        autoAPIMappings := true,
        unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(deps.map(_.project)  :_*),
        site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
        ghpagesNoJekyll := false,
        site.addMappingsToSiteDir(tut, "_tut"),
        tutScalacOptions ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
-      
+
        scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
          "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
          "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
          "-diagrams"
        ),
-       git.remoteRepo := repo,
+       git.remoteRepo := gh.repo,
        includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md")
 }

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -4,7 +4,13 @@ import sbt.Keys._
 import com.typesafe.sbt.pgp.PgpKeys
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 import com.typesafe.sbt.SbtSite.SiteKeys._
+import com.typesafe.sbt.SbtSite.site
+import com.typesafe.sbt.SbtGit._
+
 import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
+import com.typesafe.sbt.SbtGhPages.ghpages
+
+import tut.Plugin._
 import pl.project13.scala.sbt.SbtJmh._
 import sbtunidoc.Plugin.UnidocKeys._
 import sbtunidoc.Plugin._
@@ -12,126 +18,220 @@ import sbtrelease.ReleasePlugin.autoImport._
 import ReleaseTransformations._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import ScalaJSPlugin.autoImport._
+import scoverage.ScoverageSbtPlugin._
+import org.scalajs.sbtplugin.cross.CrossProject
 
 object Base {
+
+  implicit class VersionsOps(v: Map[String, String]) {
+    def ->(s: String) = v.get(s).get
+  }
+
+  val versions = Map[String, String](
+    "discipline" -> "0.4",
+    "macro-compat" -> "1.0.0",
+    "paradise" -> "2.1.0-M5",
+    "scalacheck" -> "1.12.4",
+    "scalatest" -> "3.0.0-M7",
+    "scalac" -> "2.11.7",
+    "specs2" -> "3.6.4"
+  )
+
 
   lazy val noPublishSettings = Seq(
     publish := (),
     publishLocal := (),
     publishArtifact := false
   )
-
-lazy val crossVersionSharedSources: Seq[Setting[_]] =
-  Seq(Compile, Test).map { sc =>
-    (unmanagedSourceDirectories in sc) ++= {
-      (unmanagedSourceDirectories in sc ).value.map {
-        dir:File => new File(dir.getPath + "_" + scalaBinaryVersion.value)
+  
+  lazy val rootSettings = noPublishSettings ++ Seq(
+    moduleName := "root"
+  )
+  
+  lazy val crossVersionSharedSources: Seq[Setting[_]] =
+    Seq(Compile, Test).map { sc =>
+      (unmanagedSourceDirectories in sc) ++= {
+        (unmanagedSourceDirectories in sc ).value.map {
+          dir:File => new File(dir.getPath + "_" + scalaBinaryVersion.value)
+        }
       }
     }
-  }
 
- def scalaMacrosParadise(version: String): Seq[Setting[_]] = Seq(
-   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-   libraryDependencies += compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full)
- )
+  def scalaMacrosParadise(version: String): Seq[Setting[_]] = Seq(
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+    libraryDependencies += compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full)
+  )
 
   def scalaMacroDependencies(version: String): Seq[Setting[_]] = Seq(
-  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-  libraryDependencies ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      // if scala 2.11+ is used, quasiquotes are merged into scala-reflect
-      case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
-      // in Scala 2.10, quasiquotes are provided by macro paradise
-      case Some((2, 10)) =>
-        Seq(
-          compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full),
-              "org.scalamacros" %% "quasiquotes" % version cross CrossVersion.binary
-        )
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        // if scala 2.11+ is used, quasiquotes are merged into scala-reflect
+        case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
+        // in Scala 2.10, quasiquotes are provided by macro paradise
+        case Some((2, 10)) =>
+          Seq(
+            compilerPlugin("org.scalamacros" %% "paradise" % version cross CrossVersion.full),
+                "org.scalamacros" %% "quasiquotes" % version cross CrossVersion.binary
+          )
+      } 
     }
+  )
+
+  lazy val commonScalacOptions = Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-language:existentials",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-language:experimental.macros",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Yinline-warnings",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture"
+  )
+
+  lazy val sharedCommonSettings = Seq(
+    updateOptions := updateOptions.value.withCachedResolution(true)
+  )
+
+  def sharedPublishSettings(home: String, repo: String, api: String, license: (String, URL), devs: Seq[Dev]): Seq[Setting[_]] = Seq(
+    homepage := Some(url(home)),
+    licenses += license,
+    scmInfo :=  Some(ScmInfo(url(home), "scm:git:" + repo)),
+    apiURL := Some(url(api)),
+    releaseCrossBuild := true,
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    pomIncludeRepository := Function.const(false),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("Snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("Releases" at nexus + "service/local/staging/deploy/maven2")
+    },
+    autoAPIMappings := true,
+    pomExtra := ( <developers> { devs.map(_.pomExtra) } </developers> )
+  )
+
+  lazy val sharedReleaseProcess = Seq(
+    releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      publishArtifacts,
+      setNextVersion,
+      commitNextVersion,
+      ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+      pushChanges)
+  )
+
+  def sharedScoverageSettings(min: Int = 80) = Seq(
+    ScoverageKeys.coverageMinimum := min,
+    ScoverageKeys.coverageFailOnMinimum := false,
+    ScoverageKeys.coverageHighlighting := scalaBinaryVersion.value != "2.10"
+      // ScoverageKeys.coverageExcludedPackages := "catalysts\\.bench\\..*"
+  )
+
+  lazy val unidocCommonSettings = Seq(
+    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-no-expand"
+  )
+
+  lazy val warnUnusedImport = Seq(
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 10)) =>
+          Seq()
+        case Some((2, n)) if n >= 11 =>
+          Seq("-Ywarn-unused-import")
+      }
+    },
+    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
+    scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console))
+  )
+
+  lazy val credentialSettings = Seq(
+    // For Travis CI - see http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
+    credentials ++= (for {
+      username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+      password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+    } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
+  )
+
+  // From https://github.com/typelevel/sbt-typelevel/blob/master/src/main/scala/Developer.scala
+  case class Dev(name: String, id: String) {
+    def pomExtra: xml.NodeSeq = (
+      <developer>
+        <id>{ id }</id>
+        <name>{ name }</name>
+        <url>http://github.com/{ id }</url>
+          </developer>
+    )
   }
-)
 
-lazy val commonScalacOptions = Seq(
-  "-deprecation",
-  "-encoding", "UTF-8",
-  "-feature",
-  "-language:existentials",
-  "-language:higherKinds",
-  "-language:implicitConversions",
-  "-language:experimental.macros",
-  "-unchecked",
-  "-Xfatal-warnings",
-  "-Xlint",
-  "-Yinline-warnings",
-  "-Yno-adapted-args",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-Ywarn-value-discard",
-  "-Xfuture"
-)
+  def mkConfig(projSettings: Seq[sbt.Setting[_]], jvmSettings: Seq[sbt.Setting[_]],
+    jsSettings: Seq[sbt.Setting[_]] ): CrossProject ⇒ CrossProject =
+    _.settings(projSettings:_*)
+      .jsSettings(jsSettings:_*)
+      .jvmSettings(jvmSettings:_*)
 
-lazy val sharedCommonSettings = Seq(
-  updateOptions := updateOptions.value.withCachedResolution(true) 
-)
+  def mkRootConfig(projSettings: Seq[sbt.Setting[_]] , projJVM:Project): Project ⇒ Project =
+    _.in(file("."))
+      .settings(rootSettings)
+      .settings(projSettings)
+      .settings(console <<= console in (projJVM, Compile))
 
-def sharedPublishSettings(home: String, repo: String, api: String, license: (String, URL)): Seq[Setting[_]] = Seq(
-  homepage := Some(url(home)),
-  licenses += license,
-  scmInfo :=  Some(ScmInfo(url(home), "scm:git:" + repo)),
-  apiURL := Some(url(api)),
-  releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  pomIncludeRepository := Function.const(false),
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("Snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("Releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-)
- 
-lazy val sharedReleaseProcess = Seq(
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    publishArtifacts,
-    setNextVersion,
-    commitNextVersion,
-    ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
-    pushChanges)
-)
+  def mkRootJvmConfig(s: String, projSettings: Seq[sbt.Setting[_]] , jvmSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+    _.settings(moduleName := s)
+      .settings(projSettings)
+      .settings(jvmSettings)
+      .in(file("." + s + "JVM"))
 
-lazy val unidocCommonSettings = Seq(
-  scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-no-expand"
-)
+  def mkRootJsConfig(s: String, projSettings: Seq[sbt.Setting[_]] , jsSettings: Seq[sbt.Setting[_]]): Project ⇒ Project =
+    _.settings(moduleName := s)
+      .settings(projSettings)
+      .settings(jsSettings)
+      .in(file("." + s + "JS"))
+      .enablePlugins(ScalaJSPlugin)
 
-lazy val warnUnusedImport = Seq(
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) =>
-        Seq()
-      case Some((2, n)) if n >= 11 =>
-        Seq("-Ywarn-unused-import")
-    }
-  },
-  scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
-  scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console))
-)
+  def mkDocConfig(proj: String, repo: String, org:String,  projSettings: Seq[sbt.Setting[_]] , jvmSettings: Seq[sbt.Setting[_]],
+      deps: Project*): Project ⇒ Project =
 
-lazy val credentialSettings = Seq(
-  // For Travis CI - see http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
-  credentials ++= (for {
-    username <- Option(System.getenv().get("SONATYPE_USERNAME"))
-    password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
-  } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
-)
-
+    _.settings(projSettings)
+    .settings(moduleName := proj + "-docs")
+    .settings(noPublishSettings)
+    .settings(unidocSettings)
+    .settings(site.settings)
+    .settings(tutSettings)
+    .settings(ghpages.settings)
+    .settings(jvmSettings)
+    .dependsOn(deps.map( ClasspathDependency(_, Some("compile;test->test")))  :_*) //platformJVM, macrosJVM, scalatestJVM, specs2, testkitJVM)
+    .settings(
+       organization  := org,
+       autoAPIMappings := true,
+       unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(deps.map(_.project)  :_*),
+       site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
+       ghpagesNoJekyll := false,
+       site.addMappingsToSiteDir(tut, "_tut"),
+       tutScalacOptions ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
+      
+       scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
+         "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
+         "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
+         "-diagrams"
+       ),
+       git.remoteRepo := repo,
+       includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md")
 }

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
   val apache = ("Apache License", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
   val mit = ("MIT", url("http://opensource.org/licenses/MIT"))
 
-  // Github settings and devs
+  // Github settings and related settings usually found in a Github README
   case class GitHubSettings(org: String, proj: String, publishOrg: String, license: (String, URL)) {
 
     def home = s"https://github.com/$org/$proj"
@@ -107,15 +107,21 @@ object Base {
     }
   )
 
-  lazy val commonScalacOptions = Seq(
+  lazy val scalacCommonOptions = Seq(
     "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
+    "-unchecked"
+  )
+
+  lazy val scalacLanguageOptions = Seq(
     "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-language:experimental.macros",
-    "-unchecked",
+    "-language:experimental.macros"
+  )
+
+  lazy val scalacStrictOptions = Seq(
     "-Xfatal-warnings",
     "-Xlint",
     "-Yinline-warnings",
@@ -125,6 +131,9 @@ object Base {
     "-Ywarn-value-discard",
     "-Xfuture"
   )
+
+  lazy val scalacAllOptions = scalacCommonOptions ++ scalacLanguageOptions ++ scalacStrictOptions
+
 
   lazy val sharedCommonSettings = Seq(
     updateOptions := updateOptions.value.withCachedResolution(true)
@@ -193,7 +202,7 @@ object Base {
           Seq("-Ywarn-unused-import")
       }
     },
-    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
+    scalacOptions in (Compile, console) -= "-Ywarn-unused-import",
     scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console))
   )
 
@@ -230,7 +239,7 @@ object Base {
    * 
    *   lazy val core    = prj(coreM)
    *   lazy val coreJVM = coreM.jvm
-   *   lazy val coreJS  = scalatestM.js
+   *   lazy val coreJS  = coreM.js
    *   lazy val coreM   = module("core",CrossType.Pure)
    *     .dependsOn(testkitM)
    *     .settings(addTestLibs(vlibs, "scalatest"):_*)

--- a/project/TypelevelDeps.scala
+++ b/project/TypelevelDeps.scala
@@ -7,7 +7,7 @@ object Dependencies {
   // Package -> version
   val versions = Map[String, String](
     "discipline"   -> "0.4",
-    "macro-compat" -> "1.0.0",
+    "macro-compat" -> "1.0.2",
     "paradise"     -> "2.1.0-M5",
     "scalacheck"   -> "1.12.4",
     "scalatest"    -> "3.0.0-M7",

--- a/project/TypelevelDeps.scala
+++ b/project/TypelevelDeps.scala
@@ -1,0 +1,31 @@
+package org
+package typelevel
+
+object Dependencies {
+
+  // Versions for libraries and packages
+  // Package -> version
+  val versions = Map[String, String](
+    "discipline"   -> "0.4",
+    "macro-compat" -> "1.0.0",
+    "paradise"     -> "2.1.0-M5",
+    "scalacheck"   -> "1.12.4",
+    "scalatest"    -> "3.0.0-M7",
+    "scalac"       -> "2.11.7",
+    "scalac_2.11"  -> "2.11.7",
+    "scalac_2.10"  -> "2.10.6",
+    "specs2"       -> "3.6.4"
+  )
+
+  // library definitions and links to their versions
+  // Note that one version may apply to more than one library.
+  // Library name -> version key, org, library 
+  val libraries = Map[String, (String, String, String)](
+    "discipline"        -> ("discipline"  , "org.typelevel" , "discipline"),
+    "macro-compat"      -> ("macro-compat", "org.typelevel" , "macro-compat"),
+    "scalatest"         -> ("scalatest"   , "org.scalatest" , "scalatest"),
+    "scalacheck"        -> ("scalacheck"  , "org.scalacheck", "scalacheck"),
+    "specs2-core"       -> ("specs2"      , "org.specs2"    , "specs2-core"),
+    "specs2-scalacheck" -> ("specs2"      , "org.specs2"    , "specs2-scalacheck")
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,6 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.eed3si9n"        % "sbt-unidoc"             % "0.3.3")
 addSbtPlugin("com.github.gseitz"   % "sbt-release"            % "1.0.0")
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest"            % "0.3.4")
 addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"           % "0.5.1")
 addSbtPlugin("com.jsuereth"        % "sbt-pgp"                % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"    % "sbt-ghpages"            % "0.5.3")

--- a/sbtcatalysts/src/main/scala/sbtcatalysts/Plugin.scala
+++ b/sbtcatalysts/src/main/scala/sbtcatalysts/Plugin.scala
@@ -1,0 +1,1 @@
+package sbtcatalysts


### PR DESCRIPTION

Some notes on some comments in the branch/issue:

>On the fence, but I wonder if we could just use a tuple for this: "dwijnand" -> "Dale Wijnand"
`case class Dev(name: String, id: String) {...`

=> left as is for now

>I'm not sure if all of these should be part of the plugin.
```
val versions = Map[String, String](
+    "discipline" -> "0.4",
```

=> left in as we do want to support them from a convenience POV


>thought, do we care to support multiple licences?

=> left as single for now


>also, looks like this isn't only about github, it's got publishing things and
license things..

=> Added comment  that these are setting likely found on GH page

>`def organisation  = s"com.github.$org"`
I think this is a bit too opinionated

=> not for a GH organisation

>Given the existence of "moduleName" in sbt, introducing Module might be confusing.
If we can find an alternative we should consider using it, if not so be it.

=> I see the point here, but _Module_ is far better than _Project_ simply because _anything_ is better than _Project_. Open for suggestions, though

>You certainly don't want to have your module dependsOn its JS and JVM parts
(here). aggregate, yes; dependsOn, no.

=> Originally I agreed, but then saw that when this was done in Cats, the `console` command had issues, so I will as-is for now


If Ì've left anything out, or there's more, please add in review comments