### PR TITLE
Add link for license

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+[apache]: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
This is trivial, but the formatting is currently broken because there's no link with the right name.